### PR TITLE
Removing no-op when updating counter0 in gramHistory

### DIFF
--- a/not-so-random.html
+++ b/not-so-random.html
@@ -218,7 +218,7 @@
 			iteration++; // increment iteration counter
 
 			// update the 5-gram history
-			gramHistory[historyIndex].counter0 += (1-lastKey)*(1-lastKey);
+			gramHistory[historyIndex].counter0 += (1 - lastKey);
 			gramHistory[historyIndex].counter1  += lastKey;
 		
 			// update the 5-gram buffer


### PR DESCRIPTION
Hey,

Thanks for publishing this, it's really interesting and I've enjoyed playing around and looking at the internals.

It looks like L221 could be simplified by removing the power, as our possible paths are `(1 - 0) * (1 - 0)` or `(1 - 1) * (1 - 1)` we can simplify by just keeping `1-0` or `1-1`.

Let me know if I'm missing anything, thanks again! 😄   